### PR TITLE
Fix lastActionSucceeded check.

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -285,7 +285,7 @@ class Newsletter
      */
     public function lastActionSucceeded()
     {
-        return ! $this->mailChimp->getLastError();
+        return $this->mailChimp->success();
     }
 
     /**


### PR DESCRIPTION
This change swaps the success check to use the success method in the underlying mailchimp php library: https://github.com/drewm/mailchimp-api/blob/master/src/MailChimp.php#L87

This fixes an issue where after an error occurs all further requests would return false as the error is not purged.